### PR TITLE
chore: update automatic release name

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -33,8 +33,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         with:
-          tag_name: release-${{ steps.current-time.outputs.formattedTime }}
-          release_name: Release ${{ steps.current-time.outputs.time }}
+          tag_name: code_release-${{ steps.current-time.outputs.formattedTime }}
+          release_name: (CODE-ONLY) Release ${{ steps.current-time.outputs.time }}
           body: |
             ${{ steps.Changelog.outputs.changelog }}
           draft: false


### PR DESCRIPTION
Further ACTUAL releases should contain a .jar of some sort.